### PR TITLE
Disallow 🤖

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -7,6 +7,10 @@ class App < Sinatra::Base
 
 	set :protection, :except => [:frame_options]
 
+	after do
+		headers 'X-Robots-Tag' => 'noindex, nofollow'
+	end
+
 	get '/' do
 		erb :index
 	end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -50,4 +50,9 @@ RSpec.describe "App" do
 		expect(last_response.header['X-Frame-Options']).to eq(nil)
 	end
 
+	it "should disallow robots via X-Robots-Tag" do
+		get '/'
+		expect(last_response.header['X-Robots-Tag']).to eq('noindex, nofollow')
+	end
+
 end


### PR DESCRIPTION
## What

There's no reason for this page to be indexed by search engines
independently from their host page so we add the "nofollow" and
"noindex" tags via robots.txt and X-Robot-Tag header.

## How to review

Code review

## Who

Not me or any robots